### PR TITLE
fix test directory BuildFile.xml

### DIFF
--- a/test/BuildFile.xml
+++ b/test/BuildFile.xml
@@ -1,24 +1,15 @@
-<use   name="boost"/>
-<use   name="root"/>
-<use   name="CommonTools/UtilAlgos"/>
-<use   name="Geometry/Records"/>
-<use   name="Geometry/TrackerGeometryBuilder"/>
-<use   name="CondCore/DBOutputService"/>
-<use   name="CondTools/SiPixel"/>
-<use   name="CalibTracker/SiPixelESProducers"/>
-<use   name="RecoLocalTracker/SiPixelRecHits"/>
-<use   name="CalibTracker/SiPixelConnectivity"/>
-<use   name="RecoLocalTracker/Records"/>
-<use   name="DQM/SiPixelPhase1Common"/>
-
-#<library   file="SiPixelFedCablingMapDBReader.cc" name="PixelDBTool1">
-#  <flags   EDM_PLUGIN="1"/>
-#</library>
-#
-#<library   file="SiPixelGenErrorDBReader.cc" name="PixelDBTools2">
-#  <flags   EDM_PLUGIN="1"/>
-#</library>
-
+<use name="boost"/>
+<use name="root"/>
+<use name="CommonTools/UtilAlgos"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
+<use name="CondCore/DBOutputService"/>
+<use name="CondTools/SiPixel"/>
+<use name="CalibTracker/SiPixelESProducers"/>
+<use name="RecoLocalTracker/SiPixelRecHits"/>
+<use name="CalibTracker/SiPixelConnectivity"/>
+<use name="RecoLocalTracker/Records"/>
+<use name="DQM/SiPixelPhase1Common"/>
 <library   file="*.cc" name="PixelDBTools_test">
   <flags   EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
fixes a couple of compilation warnings:
```
tmp/slc7_amd64_gcc900/MakeData/DirCache.mk:16: No such file exists: src/SiPixelTools/PixelDBTools/test/SiPixelGenErrorDBReader.cc. Please fix src/SiPixelTools/PixelDBTools/test/BuildFile.
>> Local Products Rules ..... started
gmake: *** [src/SiPixelTools/PixelDBTools/test contains only BuildFile.xml without any sources. Better to remove BuildFile.xml too or do not tag this directory] Error 1
```